### PR TITLE
Remove get Plesk limits and permissions methods

### DIFF
--- a/plib/library/DomainInfo.php
+++ b/plib/library/DomainInfo.php
@@ -17,29 +17,6 @@ class Modules_DomainInfo_DomainInfo
             'clientLogin' => $domain->getClient()->getProperty('login'),
             'hasHosting' => pm_Locale::lmsg($domain->hasHosting() ? 'yes' : 'no'),
             'ipAddresses' => $domain->getIpAddresses(),
-            'limits' => [
-                'max_site' => static::getLimit($domain, 'max_site'),
-            ],
-            'permissions' => [
-                'manage_dns' => static::getPermission($domain, 'manage_dns'),
-            ]
         ];
-    }
-
-    protected static function getLimit(pm_Domain $domain, $limitName)
-    {
-        $limit = $domain->getLimit($limitName);
-
-        return -1 === $limit ? pm_Locale::lmsg('unlimited') : $limit;
-    }
-
-    protected static function getPermission(pm_Domain $domain, $permissionName)
-    {
-        $permission = $domain->hasPermission($permissionName);
-        if (is_null($permission)) {
-            return pm_Locale::lmsg('undefined');
-        }
-
-        return pm_Locale::lmsg($permission ? 'yes' : 'no');
     }
 }

--- a/plib/resources/locales/en-US.php
+++ b/plib/resources/locales/en-US.php
@@ -19,10 +19,6 @@ $messages = [
     'vhostPath' => 'Virtual host path',
     'hasHosting' => 'Hosting',
     'listOfDomains' => 'List of domains',
-    'limits' => 'Limits',
-    'unlimited' => 'Unlimited',
-    'permissions' => 'Permissions',
     'yes' => 'Yes',
     'no' => 'No',
-    'undefined' => 'Undefined',
 ];


### PR DESCRIPTION
It is possible to get only added by extension limits and permissions. Not Plesk limits.
